### PR TITLE
Update r2.j2

### DIFF
--- a/challenge1/device_config/r2.j2
+++ b/challenge1/device_config/r2.j2
@@ -6,7 +6,6 @@ ip prefix-list MARTIAN description Martian route filter
 ip prefix-list MARTIAN seq 15 permit 10.0.0.0/8 le 32
 ip prefix-list MARTIAN seq 20 permit 127.0.0.0/8 le 32
 ip prefix-list MARTIAN seq 25 permit 169.254.0.0/16 le 32
-ip prefix-list MARTIAN seq 30 permit 172.16.0.0/12 le 32
 ip prefix-list MARTIAN seq 35 permit 192.0.2.0/24 le 32
 ip prefix-list MARTIAN seq 40 permit 192.168.0.0/16 le 32
 ip prefix-list MARTIAN seq 45 permit 198.18.0.0/15 le 32


### PR DESCRIPTION
Removed 172.16.0.0/12 le 32 from the prefix-list MARTIAN (other than the fact that it solved the connectivity issue, this prefix is not a martian address range at all).